### PR TITLE
Fixed mood-data chart x axis labeling to be dynamic

### DIFF
--- a/client/components/report-view/ReportView.jsx
+++ b/client/components/report-view/ReportView.jsx
@@ -83,6 +83,10 @@ export default class ChartComponent extends React.Component {
         var fear = 0;
         var happiness = 0;
         var dataLength = sessionData.length;
+        var moodLabel = [];
+        for (var i=1; i <= dataLength; i++) {
+          moodLabel.push(i);
+        }
         var moodData = Object.assign({}, this.state.mood);
         var expressionsData = Object.assign({}, this.state.expressions);
 
@@ -95,6 +99,7 @@ export default class ChartComponent extends React.Component {
           fear += ss.fear;
           happiness += ss.happiness;
         })
+        moodData.labels = moodLabel;
         expressionsData.datasets[0].data = [Math.floor(sadness/dataLength), Math.floor(disgust/dataLength), Math.floor(anger/dataLength),
           Math.floor(surprise/dataLength), Math.floor(fear/dataLength), Math.floor(happiness/dataLength)];
           this.setState({expressions: expressionsData, mood: moodData});


### PR DESCRIPTION
### Summary

<!--- Provide a general summary of your changes in the Title above -->
##### Description

<!--- Describe your changes in detail -->

Changed static labels for mood chart to adopt dynamic labeling by simply creating an array with range 1 through number of snapshots and swapping out the empty labels array with this newly created range array.
##### Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->
#89
##### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

To fix broken x axis labels on mood chart
##### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated Testing
- [ ] Documentation
##### Testing Details

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

<!--- If there are none to be shared, report 'Travis CI - Build Passing'  -->

Start a session by hitting the record button, let it take a few snapshots and then hit stop to see the properly rendered mood chart with dynamic x axis labeling.
##### Screenshots (if appropriate)

<!--- Report 'N/A' if none --->
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  #89
